### PR TITLE
Add example for `nil.to_nil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Or install it yourself as:
 31337.to_nil # nil
 "Yet another shitty gem".to_nil # nil
 "Your fat boss".to_nil # nil
+nil.to_nil # nil
 ```
 
 ## Contributing


### PR DESCRIPTION
It's important for coercion methods to work on their own types (e.g. `'string'.to_s`), so it should be included as an example.
